### PR TITLE
Add MarkdownViewer component

### DIFF
--- a/force-app/main/default/lwc/markdownViewer/markdownViewer.css
+++ b/force-app/main/default/lwc/markdownViewer/markdownViewer.css
@@ -1,0 +1,83 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ul,
+ol,
+table {
+    margin-bottom: 1rem;
+}
+
+h1,
+h2 {
+    border-bottom: 1px solid #dddbda;
+}
+
+h1 {
+    font-size: 3.5em;
+}
+h2 {
+    font-size: 3em;
+}
+h3 {
+    font-size: 2.5em;
+}
+h4 {
+    font-size: 2em;
+}
+h5 {
+    font-size: 1.5em;
+}
+h6 {
+    font-size: 1em;
+}
+
+h5,
+h6 {
+    font-weight: bold;
+}
+
+ul,
+ol {
+    margin-left: 2em;
+}
+ul {
+    list-style-type: disc;
+}
+ol {
+    list-style-type: decimal;
+}
+
+pre {
+    padding: 1rem;
+    background: #f8f8f8;
+}
+
+table {
+    border: 1px solid #dddbda;
+    border-collapse: collapse;
+}
+
+table th,
+table td {
+    border: 1px solid #dddbda;
+    padding: 0.5em;
+}
+
+table th[align='left'],
+table td[align='left'] {
+    text-align: left;
+}
+
+table th[align='right'],
+table td[align='right'] {
+    text-align: right;
+}
+
+table th[align='center'],
+table td[align='center'] {
+    text-align: center;
+}

--- a/force-app/main/default/lwc/markdownViewer/markdownViewer.html
+++ b/force-app/main/default/lwc/markdownViewer/markdownViewer.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/force-app/main/default/lwc/markdownViewer/markdownViewer.js
+++ b/force-app/main/default/lwc/markdownViewer/markdownViewer.js
@@ -1,0 +1,43 @@
+import { LightningElement, api } from 'lwc';
+import { loadScript } from 'lightning/platformResourceLoader';
+import MARKDOWN_LIB from '@salesforce/resourceUrl/marked';
+
+export default class MarkdownViewer extends LightningElement {
+    @api body = '';
+    _initialized = false;
+
+    renderedCallback() {
+        if (this._initialized) {
+            return;
+        }
+        this._initialized = true;
+        loadScript(this, MARKDOWN_LIB).then(() => {
+            this.renderMarkdown();
+        });
+    }
+
+    @api
+    renderMarkdown() {
+        if (window.Markdown) {
+            const md = new window.Markdown(this.body);
+            md.render(html => {
+                const container = this.template.querySelector('div');
+                if (container) {
+                    container.innerHTML = html;
+                }
+            });
+        }
+    }
+
+    @api
+    set value(val) {
+        this.body = val;
+        if (this._initialized) {
+            this.renderMarkdown();
+        }
+    }
+
+    get value() {
+        return this.body;
+    }
+}

--- a/force-app/main/default/lwc/markdownViewer/markdownViewer.js-meta.xml
+++ b/force-app/main/default/lwc/markdownViewer/markdownViewer.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add a new `markdownViewer` LWC that loads `marked` static resource
- allow passing Markdown text via the `body` property

## Testing
- `npm test` *(fails: `sfdx-lwc-jest` not found)*
- `npm run prettier:verify` *(fails: Cannot find package `prettier-plugin-apex`)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0d25e8483238e323f3dca3a12dc